### PR TITLE
Change to latlong2

### DIFF
--- a/lib/src/map.dart
+++ b/lib/src/map.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:latlng/latlng.dart';
+import 'package:latlong2/latlong.dart';
 
 /// The signature of the [Map] builder function.
 typedef MapTileBuilder = Widget Function(


### PR DESCRIPTION
Latlng is considered legacy. Latlong2 is now recommended.